### PR TITLE
babel + browserlify でコンパイルできるタスクを作成した

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,9 +16,11 @@ var concat   = require('gulp-concat');
 
 var uglify   = require("gulp-uglify");
 var plumber  = require('gulp-plumber');
-
+var fs = require("fs");
+var browserify = require("browserify");
 var browser  = require("browser-sync");
 var notify = require('gulp-notify');
+
 
 bourbon.with('scss/');
 
@@ -76,13 +78,10 @@ gulp.task('coffee', function() {
 });
 
 gulp.task('js', function() {
-  gulp.src('js/**/*.js')
-    .pipe(plumber({
-      errorHandler: notify.onError("Error: <%= error.message %>")
-    }))
-    .pipe(uglify())
-    .pipe(gulp.dest('js/'))
-    .pipe(browser.reload({stream:true}));
+  browserify("./js/script.js") // entry point
+    .transform("babelify", {presets: ["es2015"]})
+    .bundle()
+    .pipe(fs.createWriteStream("./js/bundle.js"))
 });
 
 gulp.task("server", function() {

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -1,0 +1,11 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+"use strict";
+
+var odds = evens.map(function (v) {
+  return v + 1;
+});
+var nums = evens.map(function (v, i) {
+  return v + i;
+});
+
+},{}]},{},[1]);

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,2 @@
+var odds = evens.map(v => v + 1);
+var nums = evens.map((v, i) => v + i);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
   "author": "Daisuke Konishi",
   "license": "MIT",
   "devDependencies": {
+    "babel-preset-es2015": "^6.5.0",
+    "babelify": "^7.3.0",
     "browser-sync": "^1.7.2",
+    "browserify": "^13.0.0",
+    "fs": "0.0.2",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-coffee": "^2.3.1",


### PR DESCRIPTION
#3  で作成していたES6に対応するというissueをクリアした

babelify v7.3.0 を用いての対応。
